### PR TITLE
リザルトの背景画像のサイズ縮小調整

### DIFF
--- a/Assets/Resources/Image/result/img_result_base_01.png
+++ b/Assets/Resources/Image/result/img_result_base_01.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43459ced678387e0fb72c48a5e156c17d2b73a3d5196176182f8c50b94d50415
+size 2475008

--- a/Assets/Resources/Image/result/img_result_base_01.png.meta
+++ b/Assets/Resources/Image/result/img_result_base_01.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 85fa7822a8537d14994a307f672ab4e0
+guid: ac60588a2080ab6479fefc0fbb7c81b2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -45,12 +45,12 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 0
+  spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 0
+  spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 4096
+    maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Assets/Resources/Image/result/img_result_base_02.png
+++ b/Assets/Resources/Image/result/img_result_base_02.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b1dd172831d81aeab994f52e29f1f378c59e1bc26f8ffc04ddb6da707a31de7
+size 2502873

--- a/Assets/Resources/Image/result/img_result_base_02.png.meta
+++ b/Assets/Resources/Image/result/img_result_base_02.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2d13da04ed479ba44a27a1d6000543d4
+guid: aa17cb6ad181c024fb73ad8d18f441ec
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -45,12 +45,12 @@ TextureImporter:
   compressionQuality: 50
   spriteMode: 1
   spriteExtrude: 1
-  spriteMeshType: 0
+  spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 0
+  spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -69,7 +69,7 @@ TextureImporter:
   platformSettings:
   - serializedVersion: 3
     buildTarget: DefaultTexturePlatform
-    maxTextureSize: 4096
+    maxTextureSize: 2048
     resizeAlgorithm: 0
     textureFormat: -1
     textureCompression: 1

--- a/Assets/Resources/Image/result/result_base_01.png
+++ b/Assets/Resources/Image/result/result_base_01.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:834e4f912e9fe603bc0d2e86a27cb25728dc27cafdbca57a6f7f6ccf7545cc2e
-size 5184325

--- a/Assets/Resources/Image/result/result_base_02.png
+++ b/Assets/Resources/Image/result/result_base_02.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab4ca05bfb26e5c21950a7cf6ac4c531bd4af98f4f3994a31fbf46138c2918a6
-size 5244656


### PR DESCRIPTION
■更新内容
リザルトの背景画像が大きすぎたため今の画面にあわせリサイズ